### PR TITLE
CallbackController: add support to accept Laravel\SerializableClosure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     ],
     "require": {
         "steverhoades/oauth2-openid-connect-client": "^2.0",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "laravel/serializable-closure": "^1.3"
     },
     "extra": {
         "laravel": {

--- a/config/oidc-auth.php
+++ b/config/oidc-auth.php
@@ -57,14 +57,24 @@ return [
     | JWT claims in id_token required to authenticate. Arrays set required
     | elements in an array. Other values are matched exactly.
     |
-    | You can provide a \Closure or \Laravel\SerializableClosure\SerializableClosure that accepts id_token as its argument to perform customized validation. Return true to indicate a pass or false for a fail. 
-    | When passing SerializableClosure, `APP_KEY` environment variable is used to sign and verify the serialized data.
+    | For customized validation rules, supply a \Closure that takes id_token as
+    | its input, and returns true for successful validation, false for failure.
+    | 
+    | When caching the config with artisan, wrap the closure in a serialized 
+    | \Laravel\SerializableClosure\SerializableClosure instance. Be sure to set
+    | secret key via `SerializableClosure::setSecretKey(config("app.key"));`
     |
      */
     'required_claims' => [
         // 'name' => 'value',
         // 'array' => ['required', 'elements'],
     ],
+    // Provide custom validation logic with a Closure
+    // 'required_claims' => fn ($claims) =>
+    //     $claims->has('name') && $claims->get('name') === 'value',
+    // In case you need to cache the config, make the closure serializable
+    // 'required_claims' => serialize(new SerializableClosure(
+    //     fn ($claims) => $claims->has('name') && $claims->get('name') === 'value')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/oidc-auth.php
+++ b/config/oidc-auth.php
@@ -57,13 +57,13 @@ return [
     | JWT claims in id_token required to authenticate. Arrays set required
     | elements in an array. Other values are matched exactly.
     |
-    | This can also be a Closure to check id_token. id_token will be passed as
-    | the first parameter. Return true to indicate a pass or false for a fail.
+    | You can provide a \Closure or \Laravel\SerializableClosure\SerializableClosure that accepts id_token as its argument to perform customized validation. Return true to indicate a pass or false for a fail. 
+    | When passing SerializableClosure, `APP_KEY` environment variable is used to sign and verify the serialized data.
     |
      */
     'required_claims' => [
-        //'name' => 'value',
-        //'array' => ['required', 'elements'],
+        // 'name' => 'value',
+        // 'array' => ['required', 'elements'],
     ],
 
     /*


### PR DESCRIPTION
Since Closure is not serializable, it would cause error on `artisan config:cache`. This patch provides a workaround by accepting Laravel\SerializableClosure.